### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ extension String {
 }
 
 extension Target.Dependency {
-    static let htmlToPdf: Self = .target(name: .htmlToPdf)
+    static var htmlToPdf: Self { .target(name: .htmlToPdf) }
 }
 
 let package = Package(


### PR DESCRIPTION
The manifest as is is invalid in Swift 6 language mode due to a concurrency error.

```
/Users/sas/Downloads/swift-html-to-pdf/Package.swift:11:16: error: static property 'htmlToPdf' is not concurrency-safe because non-'Sendable' type 'Target.Dependency' may have shared mutable state
 9 |
10 | extension Target.Dependency {
11 |     static let htmlToPdf: Self = .target(name: .htmlToPdf)
   |                `- error: static property 'htmlToPdf' is not concurrency-safe because non-'Sendable' type 'Target.Dependency' may have shared mutable state
12 | }
13 |
```

This fix will allow it to be added to the Swift Package Index https://github.com/SwiftPackageIndex/PackageList/issues/7573