### PR TITLE
Read the bot App id from the ruled variable, not the deleted secret

### DIFF
--- a/.github/workflows/windows-6.4-proof.yml
+++ b/.github/workflows/windows-6.4-proof.yml
@@ -57,8 +57,7 @@ jobs:
       - uses: swift-institute/.github/.github/actions/configure-private-repos@main
         with:
           token: ${{ secrets.PRIVATE_REPO_TOKEN }}
-          app-client-id: ${{ secrets.SWIFT_INSTITUTE_BOT_APP_CLIENT_ID }}
-          app-id: ${{ secrets.SWIFT_INSTITUTE_BOT_APP_ID }}
+          app-client-id: ${{ vars.SWIFT_INSTITUTE_BOT_APP_ID }}
           app-private-key: ${{ secrets.SWIFT_INSTITUTE_BOT_APP_PRIVATE_KEY }}
           enabled: true
 


### PR DESCRIPTION
Fixes a consumption of the org secrets deleted under ruling #395.

`configure-private-repos` forwards `client-id: ${{ app-client-id || app-id }}` to `actions/create-github-app-token`. This caller passed **both** inputs from the deleted secrets, so that expression resolves to empty and the action fails hard.

Adopts the #414 house pattern: one input, from the org variable `vars.SWIFT_INSTITUTE_BOT_APP_ID` (present at `swift-foundations` org scope, visibility `all`). Per the `create-github-app-token` v2+ contract — quoted in the composite action's own header — `client-id` accepts an App id as well as a Client id, so the deprecated `app-id` input is dead weight and is **removed** rather than repointed. The private key stays a secret and is untouched.

Site: `.github/workflows/windows-6.4-proof.yml` (1 site).

Part of the #395/#414 mint breakage census. Authored by peer task `mint-breakage-census`; do not merge without the coordinator.
