### PR TITLE
Raise Apple platform floors to 27

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,11 +26,11 @@ extension Target.Dependency {
 let package = Package(
     name: "swift-pdf",
     platforms: [
-        .macOS(.v26),
-        .iOS(.v26),
-        .tvOS(.v26),
-        .watchOS(.v26),
-        .visionOS(.v26),
+        .macOS("27"),
+        .iOS("27"),
+        .tvOS("27"),
+        .watchOS("27"),
+        .visionOS("27"),
     ],
     products: [
         .library(name: .pdf, targets: [.pdf]),


### PR DESCRIPTION
Uniform platform floor per swift-institute/.github#511 (26-era floors are drift; they now fail SwiftPM resolve against 27-floor dependencies). Behavior-preserving manifest-only change; hosted CI is the gate. Fleet-green campaign: swift-institute/.github#600.